### PR TITLE
Allow additional properties for the JSON schema

### DIFF
--- a/docs/js/schema.json
+++ b/docs/js/schema.json
@@ -37,7 +37,7 @@
                 "zipcode"
             ],
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "capacity_mgd": {
                     "title": "capacity_mgd",
@@ -176,7 +176,10 @@
                         "promega wastewater large volume tna capture kit",
                         "nuclisens automated magnetic bead extraction kit",
                         "nuclisens manual magnetic bead extraction kit",
-                        "phenol chloroform"
+                        "phenol chloroform",
+                        "chemagic viral dna/rna 300 kit",
+                        "trizol, zymo mag beads w/ zymo clean and concentrator",
+                        "4s method(https://www.protocols.io/view/v-4-direct-wastewater-rna-capture-and-purification-bpdfmi3n)"
                     ],
                     "enumNames": [],
                     "case_insensitive_enums": true
@@ -504,7 +507,9 @@
                         "n1 and n2 combined",
                         "n",
                         "s",
-                        "orf1a"
+                        "orf1a",
+                        "ddcov_n",
+                        "ddcov_e"
                     ],
                     "enumNames": [],
                     "case_insensitive_enums": true

--- a/nwss/schemas.py
+++ b/nwss/schemas.py
@@ -623,6 +623,9 @@ class WaterSampleSchema(
         QuantificationResults,
         Schema):
 
+    class Meta:
+        additional_properties = True
+
     @pre_load
     def cast_to_none(self, raw_data, **kwargs):
         """Cast empty strings to None to provide for the use of


### PR DESCRIPTION
## Overview
This PR changes the JSON schema to allow columns that aren't specified by the CDC's data dictionary. For #18.

### Notes
Formerly, disallowing additional properties would raise an error for duplicate fields. With this PR, duplicate fields won't be detected.

Also, I've been updating `schema.json` by executing the script manually. It looks like I didn't do that before the PR for changelog v2.0.2, so that was included inadvertently when I ran the script to allow additional properties.

## Testing Instructions
- Add a new column to your test data.
- Verify that it doesn't raise an error.
- For good measure, test with the main branch to see the error.
