### PR TITLE
Show enums for validation errors

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -126,8 +126,8 @@ class FileValidator {
                 <tr>
                     <th>Line number</th>
                     <th>Column</th>
+                    <th>Value</th>
                     <th>Error</th>
-                    <th>Input Value</th>
                 </tr>
             </thead>
             <tbody id="errors"></tbody>
@@ -152,23 +152,23 @@ class FileValidator {
             const column = lineAndColumn[2] ? lineAndColumn[2] : additionalInfo
             const allowedValues = error.params.allowedValues 
                                     ? `: <br>${error.params.allowedValues.join(', ')}` : ''
-            const inputValue = sheetData[lineAndColumn[1]][column]
+            const value = sheetData[lineAndColumn[1]][column]
 
             errorTableBody.insertAdjacentHTML(
                 'beforeend',
                 `<tr>
                     <td>${lineNumber}</td>
                     <td>${column}</td>
+                    <td>${value ? value : ''}</td>
                     <td>${error.message}${allowedValues}</td>
-                    <td>${inputValue ? inputValue : ''}</td>
                 </tr>`
             )
 
             errorData.push({
                 'line_number': lineNumber,
                 'column': column,
-                'message': error.message,
-                'input': inputValue ? inputValue : ''})
+                'value': value ? value : '',
+                'message': error.message})
         })
 
         outputDiv.appendChild(errorTable)


### PR DESCRIPTION
## Overview
This PR shows the enums whenever a field fails with a invalid enum. For issue #20.

### Notes
I had the wrong assumption when I said that the error doesn't have the enums. This is pretty simple. Let me know if you think of ways to cleanup the code or polish the UI.

## Testing Instructions
- Test by importing a CSV with an invalid enum. (I've tested by invalidating the field `quant_stan_type`.) 
- It should give you a message with enums.