### PR TITLE
Include allowed values if categorical data are missing

### DIFF
--- a/nwss/fields.py
+++ b/nwss/fields.py
@@ -1,5 +1,30 @@
 from marshmallow import fields
 
+from nwss import validators as nwss_validators
+
+
+class CategoricalString(fields.String):
+
+    def __init__(self, *args, **kwargs):
+        try:
+            allowed_values = kwargs.pop('allowed_values')
+        except KeyError:
+            raise TypeError("Missing required keyword argument 'allowed_values'")
+
+        # Add allowed value validation
+        kwargs['validate'] = nwss_validators.CaseInsensitiveOneOf(allowed_values)
+
+        # Get error_messages, if provided, or create a fresh dict
+        error_messages = kwargs.pop('error_messages', {})
+
+        # Included allowed values if data missing
+        error_messages['required'] = ('Missing data for required field. '
+                                      f'Expected one of: {", ".join(allowed_values)}')
+        kwargs['error_messages'] = error_messages
+
+        # Initialize as normal
+        super().__init__(*args, **kwargs)
+
 
 class ListString(fields.String):
     '''

--- a/nwss/schemas.py
+++ b/nwss/schemas.py
@@ -1,7 +1,7 @@
 import re
 from marshmallow import Schema, fields, \
     validate, ValidationError, validates_schema, validates
-from marshmallow.decorators import pre_load, post_load
+from marshmallow.decorators import pre_load
 
 from nwss import value_sets, fields as nwss_fields, validators as nwss_validators
 from nwss.utils import get_future_date

--- a/nwss/schemas.py
+++ b/nwss/schemas.py
@@ -1,29 +1,17 @@
 import re
 from marshmallow import Schema, fields, \
     validate, ValidationError, validates_schema, validates
-from marshmallow.decorators import pre_load
+from marshmallow.decorators import pre_load, post_load
 
-from nwss import value_sets, fields as nwss_fields
+from nwss import value_sets, fields as nwss_fields, validators as nwss_validators
 from nwss.utils import get_future_date
 
 
-class CaseInsensitiveOneOf(validate.OneOf):
-    _jsonschema_base_validator_class = validate.OneOf
-
-    def __call__(self, value) -> str:
-        try:
-            if not any(value.casefold() == v.casefold() for v in self.choices):
-                raise ValidationError(self._format_error(value))
-        except TypeError as error:
-            raise ValidationError(self._format_error(value)) from error
-
-        return value
-
 
 class CollectionSite():
-    reporting_jurisdiction = fields.String(
+    reporting_jurisdiction = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.reporting_jurisdiction)
+        allowed_values=value_sets.reporting_jurisdiction
     )
 
     county_names = nwss_fields.ListString(missing=None)
@@ -51,9 +39,9 @@ class CollectionSite():
         metadata={'units': 'Time in hours.'}
     )
 
-    sample_location = fields.String(
+    sample_location = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.sample_location)
+        allowed_values=value_sets.sample_location
     )
 
     sample_location_specify = fields.Str(
@@ -68,9 +56,9 @@ class CollectionSite():
             raise ValidationError('An "upstream" sample_location must have '
                                   'a value for sample_location_specify.')
 
-    institution_type = fields.String(
+    institution_type = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.institution_type)
+        allowed_values=value_sets.institution_type
     )
 
 
@@ -85,9 +73,9 @@ class WWTP():
         validate=validate.Length(max=40)
     )
 
-    wwtp_jurisdiction = fields.String(
+    wwtp_jurisdiction = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.wwtp_jurisdictions)
+        allowed_values=value_sets.wwtp_jurisdictions
     )
 
     capacity_mgd = fields.Float(
@@ -104,19 +92,19 @@ class WWTP():
 
     stormwater_input = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.yes_no_empty)
     )
 
     influent_equilibrated = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.yes_no_empty)
     )
 
 
 class CollectionMethod():
-    sample_type = fields.String(
+    sample_type = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.sample_type)
+        allowed_values=value_sets.sample_type
     )
 
     composite_freq = fields.Float(
@@ -128,9 +116,9 @@ class CollectionMethod():
             }
     )
 
-    sample_matrix = fields.String(
+    sample_matrix = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.sample_matrix)
+        allowed_values=value_sets.sample_matrix
     )
 
     collection_storage_time = fields.Float(
@@ -146,7 +134,7 @@ class CollectionMethod():
 
     pretreatment = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.yes_no_empty)
     )
 
     pretreatment_specify = fields.String(
@@ -166,17 +154,17 @@ class CollectionMethod():
 class ProcessingMethod():
     solids_separation = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.solids_separation)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.solids_separation)
     )
 
-    concentration_method = fields.String(
+    concentration_method = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.concentration_method)
+        allowed_values=value_sets.concentration_method
     )
 
-    extraction_method = fields.String(
+    extraction_method = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.extraction_method)
+        allowed_values=value_sets.extraction_method
     )
 
     pre_conc_storage_time = fields.Float(
@@ -209,7 +197,7 @@ class ProcessingMethod():
 
     ext_blank = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.yes_no_empty)
     )
 
     rec_eff_percent = fields.Float(
@@ -220,12 +208,12 @@ class ProcessingMethod():
 
     rec_eff_target_name = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.rec_eff_target_name)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.rec_eff_target_name)
     )
 
     rec_eff_spike_matrix = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.rec_eff_spike_matrix)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.rec_eff_spike_matrix)
     )
 
     rec_eff_spike_conc = fields.Float(
@@ -253,23 +241,23 @@ class ProcessingMethod():
 
     pasteurized = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.yes_no_empty)
     )
 
 
 class QuantificationMethod():
-    pcr_target = fields.String(
+    pcr_target = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.pcr_target)
+        allowed_values=value_sets.pcr_target
     )
 
     pcr_target_ref = fields.String(
         required=True
     )
 
-    pcr_type = fields.String(
+    pcr_type = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.pcr_type)
+        allowed_values=value_sets.pcr_type
     )
 
     lod_ref = fields.String(
@@ -283,12 +271,12 @@ class QuantificationMethod():
 
     hum_frac_mic_unit = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.mic_units)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.mic_units)
     )
 
     hum_frac_target_mic = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.hum_frac_target_mic)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.hum_frac_target_mic)
     )
 
     hum_frac_target_mic_ref = fields.String(
@@ -324,12 +312,12 @@ class QuantificationMethod():
 
     hum_frac_chem_unit = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.chem_units)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.chem_units)
     )
 
     hum_frac_target_chem = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.hum_frac_target_chem)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.hum_frac_target_chem)
     )
 
     hum_frac_target_chem_ref = fields.String(
@@ -363,12 +351,12 @@ class QuantificationMethod():
 
     other_norm_name = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.other_norm_name)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.other_norm_name)
     )
 
     other_norm_unit = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.mic_chem_units)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.mic_chem_units)
     )
 
     other_norm_ref = fields.String(
@@ -395,23 +383,23 @@ class QuantificationMethod():
                     'other_norm_name cannot be null.'
             )
 
-    quant_stan_type = fields.String(
+    quant_stan_type = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.quant_stan_type)
+        allowed_values=value_sets.quant_stan_type
     )
 
     stan_ref = fields.String(
         required=True
     )
 
-    inhibition_detect = fields.String(
+    inhibition_detect = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_not_tested)
+        allowed_values=value_sets.yes_no_not_tested
     )
 
-    inhibition_adjust = fields.String(
+    inhibition_adjust = nwss_fields.CategoricalString(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        allowed_values=value_sets.yes_no_empty
     )
 
     inhibition_method = fields.String(
@@ -435,9 +423,9 @@ class QuantificationMethod():
                 "if inhibition_detect == 'not tested'."
             )
 
-    num_no_target_control = fields.String(
+    num_no_target_control = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.num_no_target_control)
+        allowed_values=value_sets.num_no_target_control
     )
 
 
@@ -561,9 +549,9 @@ class QuantificationResults():
                 "before 'sample_collect_date'."
             )
 
-    sars_cov2_units = fields.String(
+    sars_cov2_units = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.mic_chem_units)
+        allowed_values=value_sets.mic_chem_units
     )
 
     sars_cov2_avg_conc = fields.Float(
@@ -602,14 +590,14 @@ class QuantificationResults():
                    "must be empty."
                )
 
-    ntc_amplify = fields.String(
+    ntc_amplify = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no)
+        allowed_values=value_sets.yes_no
     )
 
-    sars_cov2_below_lod = fields.String(
+    sars_cov2_below_lod = nwss_fields.CategoricalString(
         required=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no)
+        allowed_values=value_sets.yes_no
     )
 
     lod_sewage = fields.Float(
@@ -619,7 +607,7 @@ class QuantificationResults():
 
     quality_flag = fields.String(
         allow_none=True,
-        validate=CaseInsensitiveOneOf(value_sets.yes_no_empty)
+        validate=nwss_validators.CaseInsensitiveOneOf(value_sets.yes_no_empty)
     )
 
 

--- a/nwss/validators.py
+++ b/nwss/validators.py
@@ -1,0 +1,14 @@
+from marshmallow import validate, ValidationError
+
+
+class CaseInsensitiveOneOf(validate.OneOf):
+    _jsonschema_base_validator_class = validate.OneOf
+
+    def __call__(self, value) -> str:
+        try:
+            if not any(value.casefold() == v.casefold() for v in self.choices):
+                raise ValidationError(self._format_error(value))
+        except TypeError as error:
+            raise ValidationError(self._format_error(value)) from error
+
+        return value


### PR DESCRIPTION
## Overview

TODO: Switch base after #36 comes in.

Closes #33 

### Demo

```python
>>> from nwss.schemas import WaterSampleSchema
>>> s = WaterSampleSchema()
>>> s.load({})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hannah/.virtualenvs/nwss-data-standard/lib/python3.7/site-packages/marshmallow/schema.py", line 726, in load
    data, many=many, partial=partial, unknown=unknown, postprocess=True
  File "/Users/hannah/.virtualenvs/nwss-data-standard/lib/python3.7/site-packages/marshmallow/schema.py", line 907, in _do_load
    raise exc
marshmallow.exceptions.ValidationError: {'sample_collect_time': ['Missing data for required field.'], 'reporting_jurisdiction': ['Missing data for required field. Expected one of: AL, AK, AS, AZ, CA, CI, CO, MP, CT, DE, DC, FM, FL, GA, GU, HI, HO, ID, IL, IN, IA, KS, KY, LC, LA, ME, MD, MA, MI, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NZ, NC, ND, OH, OK, OR, PA, PH, PR, MH, PW, RI, SC, SD, TN, TX, VI, UT, VT, VA, WA, WV, WI, WY'], 'lab_id': ['Missing data for required field.'], 'extraction_method': ['Missing data for required field. Expected one of: qiagen allprep powerviral dna/rna kit, qiagen allprep powerfecal dna/rna kit, qiange allprep dna/rna kit, qiagen rneasy powermicrobiome kit, qiagen powerwater kit, qiagen rneasy kit, promega ht tna kit, promega automated tna kit, promega manual tna kit, promega wastewater large volume tna capture kit, nuclisens automated magnetic bead extraction kit, nuclisens manual magnetic bead extraction kit, phenol chloroform, chemagic viral dna/rna 300 kit, trizol, zymo mag beads w/ zymo clean and concentrator, 4s method (https://www.protocols.io/view/v-4-direct-wastewater-rna-capture-and-purification-bpdfmi3n), qiagen qiaamp buffers with epoch columns'], 'lod_ref': ['Missing data for required field.'], 'zipcode': ['Missing data for required field.'], 'capacity_mgd': ['Missing data for required field.'], 'stan_ref': ['Missing data for required field.'], 'sample_matrix': ['Missing data for required field. Expected one of: raw wastewater, post grit removal, primary sludge, primary effluent, secondary sludge, secondary effluent, septage, holding tank'], 'sample_location': ['Missing data for required field. Expected one of: wwtp, upstream'], 'lod_sewage': ['Missing data for required field.'], 'sars_cov2_units': ['Missing data for required field. Expected one of: copies/L wastewater, log10 copies/L wastewater, copies/g wet sludge, log10 copies/g wet sludge, copies/g dry sludge, log10 copies/g dry sludge, micrograms/L wastewater, log10 micrograms/L wastewater, micrograms/g wet sludge, log10 micrograms/g wet sludge, micrograms/g dry sludge, log10 micrograms/g dry sludge'], 'inhibition_method': ['Missing data for required field.'], 'concentration_method': ['Missing data for required field. Expected one of: membrane filtration with addition of mgcl2, membrane filtration with sample acidification, membrane filtration with acidification and mgcl2, membrane filtration with no amendment, membrane filtration with addition of mgcl2, membrane recombined with separated solids, membrane filtration with sample acidification, membrane recombined with separated solids, membrane filtration with acidification and mgcl2, membrane recombined with separated solids, membrane filtration with no amendment,membrane recombined with separated solids, peg precipitation, ultracentrifugation, skimmed milk flocculation, beef extract flocculation, promega wastewater large volume tna capture kit, centricon ultrafiltration, amicon ultrafiltration, hollow fiber dead end ultrafiltration, no liquid concentration, liquid recombined with separated solids, innovaprep ultrafiltration, none'], 'wwtp_jurisdiction': ['Missing data for required field. Expected one of: AL, AK, AS, AZ, CA, CO, MP, CT, DE, DC, FM, FL, GA, GU, HI, ID, IL, IN, IA, KS, KY, LA, ME, MD, MA, MI, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NC, ND, OH, OK, OR, PA, PR, MH, PW, RI, SC, SD, TN, TX, VI, UT, VT, VA, WA, WV, WI, WY'], 'test_result_date': ['Missing data for required field.'], 'sars_cov2_avg_conc': ['Missing data for required field.'], 'sars_cov2_below_lod': ['Missing data for required field. Expected one of: yes, no'], 'sample_collect_date': ['Missing data for required field.'], 'pcr_target_ref': ['Missing data for required field.'], 'pcr_type': ['Missing data for required field. Expected one of: qpcr, ddpcr, qiagen dpcr, fluidigm dpcr, life technologies dpcr, raindance dpcr'], 'wwtp_name': ['Missing data for required field.'], 'rec_eff_percent': ['Missing data for required field.'], 'sample_type': ['Missing data for required field. Expected one of: grab, 30-hr flow-weighted composite, 29-hr flow-weighted composite, 28-hr flow-weighted composite, 27-hr flow-weighted composite, 26-hr flow-weighted composite, 25-hr flow-weighted composite, 24-hr flow-weighted composite, 23-hr flow-weighted composite, 22-hr flow-weighted composite, 21-hr flow-weighted composite, 20-hr flow-weighted composite, 19-hr flow-weighted composite, 18-hr flow-weighted composite, 17-hr flow-weighted composite, 16-hr flow-weighted composite, 15-hr flow-weighted composite, 14-hr flow-weighted composite, 13-hr flow-weighted composite, 12-hr flow-weighted composite, 11-hr flow-weighted composite, 10-hr flow-weighted composite, 9-hr flow-weighted composite, 8-hr flow-weighted composite, 7-hr flow-weighted composite, 6-hr flow-weighted composite, 5-hr flow-weighted composite, 4-hr flow-weighted composite, 3-hr flow-weighted composite, 2-hr flow-weighted composite, 1-hr flow-weighted composite, 30-hr time-weighted composite, 29-hr time-weighted composite, 28-hr time-weighted composite, 27-hr time-weighted composite, 26-hr time-weighted composite, 25-hr time-weighted composite, 24-hr time-weighted composite, 23-hr time-weighted composite, 22-hr time-weighted composite, 21-hr time-weighted composite, 20-hr time-weighted composite, 19-hr time-weighted composite, 18-hr time-weighted composite, 17-hr time-weighted composite, 16-hr time-weighted composite, 15-hr time-weighted composite, 14-hr time-weighted composite, 13-hr time-weighted composite, 12-hr time-weighted composite, 11-hr time-weighted composite, 10-hr time-weighted composite, 9-hr time-weighted composite, 8-hr time-weighted composite, 7-hr time-weighted composite, 6-hr time-weighted composite, 5-hr time-weighted composite, 4-hr time-weighted composite, 3-hr time-weighted composite, 2-hr time-weighted composite, 1-hr time-weighted composite, 30-hr manual composite, 29-hr manual composite, 28-hr manual composite, 27-hr manual composite, 26-hr manual composite, 25-hr manual composite, 24-hr manual composite, 23-hr manual composite, 22-hr manual composite, 21-hr manual composite, 20-hr manual composite, 19-hr manual composite, 18-hr manual composite, 17-hr manual composite, 16-hr manual composite, 15-hr manual composite, 14-hr manual composite, 13-hr manual composite, 12-hr manual composite, 11-hr manual composite, 10-hr manual composite, 9-hr manual composite, 8-hr manual composite, 7-hr manual composite, 6-hr manual composite, 5-hr manual composite, 4-hr manual composite, 3-hr manual composite, 2-hr manual composite, 1-hr manual composite'], 'sample_id': ['Missing data for required field.'], 'population_served': ['Missing data for required field.'], 'num_no_target_control': ['Missing data for required field. Expected one of: 0, 1, 2, 3, more than 3'], 'ntc_amplify': ['Missing data for required field. Expected one of: yes, no'], 'quant_stan_type': ['Missing data for required field. Expected one of: dna, rna'], 'pcr_target': ['Missing data for required field. Expected one of: n1, n2, n3, e_sarbeco, n_sarbeco, rdrp_sarsr, niid_2019-ncov_n, rdrp gene / ncov_ip2, rdrp gene / ncov_ip4, taqpath n, taqpath s, orf1b, orf1ab, n1 and n2 combined, n, s, orf1a, ddcov_n, ddcov_e'], 'institution_type': ['Missing data for required field. Expected one of: not institution specific, correctional, long term care - nursing home, long term care - assisted living, other long term care, short stay acute care hospital, long term acute care hospital, child day care, k12, higher ed dorm, higher ed other, social services shelter, other residential building, ship, airplane'], 'inhibition_detect': ['Missing data for required field. Expected one of: yes, no, not tested']}
>>> exit()
```

### Notes

I switched the field type for required categorical strings but left non-required fields as normal strings to reduce the diff. Is this ok, @smcalilly, or would you prefer I switch them all? 

## Testing Instructions

* Confirm the tests pass.
* Review the diff and confirm changes are legible.