### PR TITLE
Update validation of stderr fields

### DIFF
--- a/nwss/schemas.py
+++ b/nwss/schemas.py
@@ -576,18 +576,14 @@ class QuantificationResults():
 
     @validates_schema
     def validate_sars_cov2(self, data, **kwargs):
-        fields = [
-            'sars_cov2_std_error',
-            'sars_cov2_cl_95_lo',
-            'sars_cov2_cl_95_up'
-        ]
+        has_stderr = data.get('sars_cov2_std_error')
+        has_lo_up = data.get('sars_cov2_cl_95_lo') and data.get('sars_cov2_cl_95_up')
 
-        if all(data.get(field) for field in fields):
+        if not any([has_stderr, has_lo_up]):
             raise ValidationError(
-                   "If 'sars_cov2_std_error' has a non-empty value then "
-                   "'sars_cov2_cl_95_lo' and 'sars_cov2_cl_95_up' "
-                   "must be empty."
-               )
+                "Either 'sars_cov2_std_error' or both 'sars_cov2_cl_95_lo' "
+                "and 'sars_cov2_cl_95_up' must have a non-empty value."
+            )
 
     ntc_amplify = nwss_fields.CategoricalString(
         required=True,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2140,14 +2140,13 @@ def test_sars_cov2_units(schema, valid_data, input, expect, error):
         ),
         (
             {
-                'sars_cov2_std_error': 0.09214,
-                'sars_cov2_cl_95_lo': 123984,
-                'sars_cov2_cl_95_up': 4450494
+                'sars_cov2_std_error': None,
+                'sars_cov2_cl_95_lo': None,
+                'sars_cov2_cl_95_up': None
             },
             pytest.raises(ValidationError),
-            "If 'sars_cov2_std_error' has a non-empty value "
-            "then 'sars_cov2_cl_95_lo' and "
-            "'sars_cov2_cl_95_up' must be empty."
+            "Either 'sars_cov2_std_error' or both 'sars_cov2_cl_95_lo' "
+            "and 'sars_cov2_cl_95_up' must have a non-empty value."
         )
     ]
 )


### PR DESCRIPTION
## Overview

This PR updates validation to expect either standard error or lo/up fields.

The expected validation is described in the data dictionary as:

> Either 'sars_cov2_std_error' or ('sars_cov2_cl_95_lo' and 'sars_cov2_cl_95_up') must have a non-empty value

## Testing Instructions

* Confirm tests pass and change is straightforward.